### PR TITLE
Fix torch load from Pytorch 2.6

### DIFF
--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -515,7 +515,7 @@ def torch_safe_load(weight):
     check_suffix(file=weight, suffix='.pt')
     file = attempt_download_asset(weight)  # search online if missing locally
     try:
-        return torch.load(file, map_location='cpu'), file  # load
+        return torch.load(file, map_location='cpu', weights_only=False), file  # load
     except ModuleNotFoundError as e:  # e.name is missing module name
         if e.name == 'models':
             raise TypeError(


### PR DESCRIPTION
Hi, when loading your model with `torch.hub.load`, it run into the following problem:

```
    mobilesamv2, ObjAwareModel, predictor = torch.hub.load("RogerQi/MobileSAMV2", args.mobilesamv2_encoder_name, force_reload=True)
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/david/.venv/lib/python3.12/site-packages/torch/hub.py", line 647, in load
    model = _load_local(repo_or_dir, model, *args, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/david/.venv/lib/python3.12/site-packages/torch/hub.py", line 680, in _load_local
    model = entry(*args, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/david/.cache/torch/hub/RogerQi_MobileSAMV2_main/hubconf.py", line 82, in mobilesamv2_efficientvit_l2
    return _get_everything('efficientvit_l2')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/david/.cache/torch/hub/RogerQi_MobileSAMV2_main/hubconf.py", line 75, in _get_everything
    obj_aware_model = _get_object_aware_model()
                      ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/david/.cache/torch/hub/RogerQi_MobileSAMV2_main/hubconf.py", line 40, in _get_object_aware_model
    ObjAwareModel = ObjectAwareModel(object_aware_model_path)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/david/.cache/torch/hub/RogerQi_MobileSAMV2_main/ultralytics/yolo/engine/model.py", line 107, in __init__
    self._load(model, task)
  File "/home/david/.cache/torch/hub/RogerQi_MobileSAMV2_main/ultralytics/yolo/engine/model.py", line 156, in _load
    self.model, self.ckpt = attempt_load_one_weight(weights)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/david/.cache/torch/hub/RogerQi_MobileSAMV2_main/ultralytics/nn/tasks.py", line 578, in attempt_load_one_weight
    ckpt, weight = torch_safe_load(weight)  # load ckpt
                   ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/david/.cache/torch/hub/RogerQi_MobileSAMV2_main/ultralytics/nn/tasks.py", line 518, in torch_safe_load
    return torch.load(file, map_location='cpu'), file  # load
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/david/.venv/lib/python3.12/site-packages/torch/serialization.py", line 1524, in load
    raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
        (1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
        (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
        WeightsUnpickler error: Unsupported global: GLOBAL ultralytics.nn.tasks.SegmentationModel was not an allowed global by default. Please use `torch.serialization.add_safe_globals([ultralytics.nn.tasks.SegmentationModel])` or the `torch.serialization.safe_globals([ultralytics.nn.tasks.SegmentationModel])` context manager to allowlist this global if you trust this class/function.
```

This is due to Pytorch 2.6+ setting weights_only=True, which prevents loading arbitrary code for security reasons. This leads to the error when the checkpoint contains not just weights, but also class definitions (e.g., a full model object). The easiest fix is to explicitly set `weights_only=False` if the source is trusted (which it is since it's ultralytics). I guess this doesn't break anything in previous versions.